### PR TITLE
Adds icc_rt sub-package, make dpcpp-cpp-rt rt-depends on it

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -148,12 +148,12 @@ outputs:
         - {{ compiler('c') }}
         - patchelf                 # [linux]
       host:
-        - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
-        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        # [osx]
+        - {{ pin_subpackage('intel-cmplr-lib-rt', min_pin='x', max_pin='x') }}  # [not osx]
+        - {{ pin_subpackage('dpcpp-cpp-rt', min_pin='x', max_pin='x') }}        # [osx]
       run:
-        - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
-        - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
-        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        # [osx]
+        - {{ pin_subpackage('intel-cmplr-lic-rt', min_pin='x', max_pin='x') }}
+        - {{ pin_subpackage('intel-cmplr-lib-rt', min_pin='x', max_pin='x') }}  # [not osx]
+        - {{ pin_subpackage('dpcpp-cpp-rt', min_pin='x', max_pin='x') }}        # [osx]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 {% set tbb_version = "2021.6.0" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '0' %}
+{% set dst_build_number = '1' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -23,6 +23,8 @@ source:
     folder: intel-cmplr-lic-rt
   - url: https://anaconda.org/intel/intel-fortran-rt/{{ version }}/download/{{ target_platform }}/intel-fortran-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
     folder: intel-fortran-rt
+  - url: https://anaconda.org/intel/icc_rt/{{ version }}/download/{{ target_platform }}/icc_rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2
+    folder: icc_rt
   - url: https://anaconda.org/intel/dpcpp-cpp-rt/{{ version }}/download/{{ target_platform }}/dpcpp-cpp-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2  # [not win32]
     folder: dpcpp-cpp-rt  # [not win32]
   - url: https://anaconda.org/intel/intel-cmplr-lib-rt/{{ version }}/download/{{ target_platform }}/intel-cmplr-lib-rt-{{ version }}-intel_{{ intel_build_number }}.tar.bz2  # [not osx]
@@ -135,6 +137,41 @@ outputs:
         - ls -A1 ${PREFIX}/lib/*  # [unix]
         - dir %PREFIX%\Library\bin\*  # [win]
 
+  - name: icc_rt
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:                               # [osx]
+      missing_dso_whitelist:             # [osx]
+        - '**/for_mac_ftn_alloc.dylib'   # [osx]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - patchelf                 # [linux]
+      host:
+        - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
+        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        # [osx]
+      run:
+        - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
+        - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
+        - {{ pin_subpackage('dpcpp-cpp-rt', exact=True) }}        # [osx]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top.html
+      summary: Runtime for Intel® Fortran Compiler Classic and Intel® Fortran Compiler (Beta)
+      license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+      license_family: Proprietary
+      license_file: 
+        - icc_rt/info/licenses/license.txt
+        - icc_rt/info/licenses/tpp.txt
+      description: |
+        Runtime for Intel® oneAPI DPC++/C++ Compiler & Intel® C++ Compiler Classic 2022.1.0.
+        This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+    test:
+      commands:
+        - ls -A1 ${PREFIX}/lib/*  # [unix]
+        - dir %PREFIX%\Library\bin\*  # [win]
+
   - name: intel-opencl-rt
     script: opencl-rt-build.sh   # [unix]
     script: opencl-rt-bld.bat  # [win]
@@ -201,6 +238,7 @@ outputs:
       run:
         - _openmp_mutex * *_llvm   # [linux]
         - llvm-openmp              # [not linux]
+        - {{ pin_subpackage('icc_rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
         - {{ pin_subpackage('intel-opencl-rt', exact=True) }}     # [not osx]
@@ -367,4 +405,3 @@ extra:
     - napetrov
     - tomashek
     - oleksandr-pavlyk
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ outputs:
       summary: Intel End User License Agreement for Developer Tools
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - intel-cmplr-lic-rt/info/licenses/license.txt
         - intel-cmplr-lic-rt/info/licenses/tpp.txt
       description: |
@@ -87,7 +87,7 @@ outputs:
       summary: Runtime for Intel® C++ Compiler Classic
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - intel-cmplr-lib-rt/info/licenses/license.txt
         - intel-cmplr-lib-rt/info/licenses/tpp.txt
       description: |
@@ -126,7 +126,7 @@ outputs:
       summary: Runtime for Intel® Fortran Compiler Classic and Intel® Fortran Compiler (Beta)
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - intel-fortran-rt/info/licenses/license.txt
         - intel-fortran-rt/info/licenses/tpp.txt
       description: |
@@ -161,7 +161,7 @@ outputs:
       summary: Runtime for Intel® Fortran Compiler Classic and Intel® Fortran Compiler (Beta)
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - icc_rt/info/licenses/license.txt
         - icc_rt/info/licenses/tpp.txt
       description: |
@@ -238,7 +238,7 @@ outputs:
       run:
         - _openmp_mutex * *_llvm   # [linux]
         - llvm-openmp              # [not linux]
-        - {{ pin_subpackage('icc_rt', exact=True) }}
+        - {{ pin_subpackage('icc_rt', min_pin='x.x', max_pin='x.x') }}
         - {{ pin_subpackage('intel-cmplr-lic-rt', exact=True) }}
         - {{ pin_subpackage('intel-cmplr-lib-rt', exact=True) }}  # [not osx]
         - {{ pin_subpackage('intel-opencl-rt', exact=True) }}     # [not osx]
@@ -249,7 +249,7 @@ outputs:
       summary: Runtime for Intel® oneAPI DPC++/C++ Compiler
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - dpcpp-cpp-rt/info/licenses/license.txt
         - dpcpp-cpp-rt/info/licenses/tpp.txt
       description: |
@@ -295,7 +295,7 @@ outputs:
       summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
       license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
       license_family: Proprietary
-      license_file: 
+      license_file:
         - dpcpp_impl_{{ target_platform }}/info/licenses/license.txt  # [linux64 or win64]
         - dpcpp_impl_{{ target_platform }}/info/licenses/tpp.txt      # [linux64 or win64]
       description: |
@@ -384,7 +384,7 @@ outputs:
       summary: Intel® oneAPI Collective Communications Library*
       license: LicenseRef-Proprietary-Intel-Simplified-Software-License
       license_family: Proprietary
-      license_file: 
+      license_file:
         - oneccl-devel/info/licenses/license.txt
         - oneccl-devel/info/licenses/tpp.txt
       description: |


### PR DESCRIPTION
Adds icc_rt subpackage output, makes icc_rt runtime dependency of dpcpp-cpp-rt as it is with Intel's packages from which we are repacking.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
