### PR TITLE
Fix CXX to icx on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 {% set tbb_version = "2021.10.0" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '4' %}
+{% set dst_build_number = '5' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:

--- a/recipe/scripts/activate-dpcpp.bat
+++ b/recipe/scripts/activate-dpcpp.bat
@@ -1,2 +1,2 @@
 set "CC=icx"
-set "CXX=icpx"
+set "CXX=icx"


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

CXX must be `icx.exe` in order to work on Windows with MSVC.

<!--
Please add any other relevant info below:
-->
