### PR TITLE
Add run_exports to rt packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 {% set intel_ch = "https://anaconda.org/intel" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '1' %}
+{% set dst_build_number = '2' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -54,6 +54,10 @@ outputs:
   - name: intel-cmplr-lic-rt
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
+    build:
+      run_exports:
+        # Pin to year for now, similar to MKL.
+        - {{ pin_subpackage("intel-cmplr-lic-rt", max_pin="x") }}
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       doc_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
@@ -75,6 +79,10 @@ outputs:
   - name: intel-cmplr-lib-rt
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
+    build:
+      run_exports:
+        # Pin to year for now, similar to MKL.
+        - {{ pin_subpackage("intel-cmplr-lib-rt", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -106,6 +114,10 @@ outputs:
   - name: intel-fortran-rt
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
+    build:
+      run_exports:
+        # Pin to year for now, similar to MKL.
+        - {{ pin_subpackage("intel-fortran-rt", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -145,6 +157,9 @@ outputs:
       ignore_run_exports:        # [win]
         - python_abi             # [win]
         - python                 # [win]
+      run_exports:
+        # Pin to year for now, similar to MKL.
+        - {{ pin_subpackage("intel-opencl-rt", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
Add `run_exports` to runtime packages so that they can be added to build section and populate run requirements of the target.

Fixes: #37 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
