### PR TITLE
Fix umf package version

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -22,14 +22,10 @@ cxx_compiler_version:
 - 7.5.0
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '13'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 mpich:
 - '4'
 pin_run_as_build:
@@ -43,6 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - fortran_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -22,14 +22,10 @@ cxx_compiler_version:
 - 7.5.0
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '13'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 mpich:
 - '4'
 pin_run_as_build:
@@ -43,6 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - fortran_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -22,14 +22,10 @@ cxx_compiler_version:
 - 7.5.0
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '13'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 mpich:
 - '4'
 pin_run_as_build:
@@ -43,6 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - fortran_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -22,14 +22,10 @@ cxx_compiler_version:
 - 7.5.0
 docker_image:
 - quay.io/condaforge/linux-anvil-alma-x86_64:8
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '13'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 mpich:
 - '4'
 pin_run_as_build:
@@ -43,6 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-  - fortran_compiler_version
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -10,14 +10,10 @@ curl:
 - '8'
 cxx_compiler:
 - vs2019
-fortran_compiler:
-- flang
-fortran_compiler_version:
-- '5'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -10,14 +10,10 @@ curl:
 - '8'
 cxx_compiler:
 - vs2019
-fortran_compiler:
-- flang
-fortran_compiler_version:
-- '5'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -10,14 +10,10 @@ curl:
 - '8'
 cxx_compiler:
 - vs2019
-fortran_compiler:
-- flang
-fortran_compiler_version:
-- '5'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -10,14 +10,10 @@ curl:
 - '8'
 cxx_compiler:
 - vs2019
-fortran_compiler:
-- flang
-fortran_compiler_version:
-- '5'
 libhwloc:
 - 2.11.2
 libxml2:
-- '2'
+- '2.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/README.md
+++ b/README.md
@@ -119,23 +119,6 @@ Intel® CPU Runtime for OpenCL(TM) Applications
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
-About ifx_impl_linux-64
------------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Implementation for Intel® Fortran Compiler
-
-Development: https://www.intel.com/content/www/us/en/docs/fortran-compiler/get-started-guide/2025-0/overview.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html
-
-Implementation for Intel® Fortran Compiler.
-This package is a repackaged set of binaries obtained directly from Intel channel.
-
-
 About intel-sycl-rt
 -------------------
 
@@ -185,23 +168,6 @@ Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi
 
 Implementation for Intel® oneAPI DPC++/C++ Compiler.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
-
-
-About ifx_linux-64
-------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Implementation for Intel® Fortran Compiler
-
-Development: https://www.intel.com/content/www/us/en/docs/fortran-compiler/get-started-guide/2025-0/overview.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html
-
-Activation for Intel® Fortran Compiler.
-This package is a repackaged set of binaries obtained directly from Intel channel.
 
 
 About oneccl-devel
@@ -397,9 +363,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_impl_win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_linux--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_impl_linux--64-green.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_impl_win--64-green.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_linux--64-green.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_win--64-green.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-intel--cmplr--lib--rt-green.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-intel--cmplr--lib--ur-green.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) |
@@ -420,16 +384,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `dpcpp-cpp-rt, dpcpp_impl_linux-64, dpcpp_impl_win-64, dpcpp_linux-64, dpcpp_win-64, ifx_impl_linux-64, ifx_impl_win-64, ifx_linux-64, ifx_win-64, intel-cmplr-lib-rt, intel-cmplr-lib-ur, intel-cmplr-lic-rt, intel-fortran-rt, intel-opencl-rt, intel-sycl-rt, oneccl-devel, umf` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `dpcpp-cpp-rt, dpcpp_impl_linux-64, dpcpp_impl_win-64, dpcpp_linux-64, dpcpp_win-64, ifx_impl_win-64, ifx_win-64, intel-cmplr-lib-rt, intel-cmplr-lib-ur, intel-cmplr-lic-rt, intel-fortran-rt, intel-opencl-rt, intel-sycl-rt, oneccl-devel, umf` can be installed with `conda`:
 
 ```
-conda install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_linux-64 ifx_impl_win-64 ifx_linux-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
+conda install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_win-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
 ```
 
 or with `mamba`:
 
 ```
-mamba install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_linux-64 ifx_impl_win-64 ifx_linux-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
+mamba install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_win-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
 ```
 
 It is possible to list all of the versions of `dpcpp-cpp-rt` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -648,6 +648,7 @@ outputs:
         - ls -A1 $PREFIX/lib/*  # [unix]
 
   - name: umf
+    version: {{ umf_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Turns out that `umf` package has incorrect version because it wasn't explicitly set in `umf` section.