### PR TITLE
Bump build number so intel-cmplr-lib-ur pins to umf 0.10.0

### DIFF
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/README.md
+++ b/README.md
@@ -13,21 +13,89 @@ Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Dev
 
 Summary: Repackaged Intel® compilers and runtimes.
 
-About intel-cmplr-lic-rt
-------------------------
+About dpcpp-cpp-rt
+------------------
 
 Home: https://software.intel.com/content/www/us/en/develop/tools.html
 
 Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
 
-Summary: Intel End User License Agreement for Developer Tools
+Summary: Runtime for Intel® oneAPI DPC++/C++ Compiler
 
-Development: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
 
-Documentation: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
 
-Intel End User License Agreement for Developer Tools.
+Runtime for Intel® oneAPI DPC++/C++ Compiler.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+
+
+About dpcpp_impl_linux-64
+-------------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
+
+Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
+
+Implementation for Intel® oneAPI DPC++/C++ Compiler.
+This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+
+
+About dpcpp_linux-64
+--------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
+
+Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
+
+Activation for Intel® oneAPI DPC++/C++ Compiler.
+This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+
+
+About ifx_impl_linux-64
+-----------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Implementation for Intel® Fortran Compiler
+
+Development: https://www.intel.com/content/www/us/en/docs/fortran-compiler/get-started-guide/2025-0/overview.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html
+
+Implementation for Intel® Fortran Compiler.
+This package is a repackaged set of binaries obtained directly from Intel channel.
+
+
+About ifx_linux-64
+------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Implementation for Intel® Fortran Compiler
+
+Development: https://www.intel.com/content/www/us/en/docs/fortran-compiler/get-started-guide/2025-0/overview.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/fortran-compiler.html
+
+Activation for Intel® Fortran Compiler.
+This package is a repackaged set of binaries obtained directly from Intel channel.
 
 
 About intel-cmplr-lib-rt
@@ -47,27 +115,6 @@ Runtime for Intel® C++ Compiler Classic.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
-About umf
----------
-
-Home: https://github.com/oneapi-src/unified-memory-framework
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: A library for constructing allocators and memory pools
-
-Development: https://github.com/oneapi-src/unified-memory-framework
-
-Documentation: https://oneapi-src.github.io/unified-memory-framework/
-
-The Unified Memory Framework (UMF) is a library for constructing
-allocators and memory pools. It also contains broadly useful
-abstractions and utilities for memory management. UMF allows users to
-manage multiple memory pools characterized by different attributes,
-allowing certain allocation types to be isolated from others and
-allocated using different hardware resources as required.
-
-
 About intel-cmplr-lib-ur
 ------------------------
 
@@ -82,6 +129,23 @@ Development: https://software.intel.com/content/www/us/en/develop/documentation/
 Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
 
 Runtime for Intel® C++ Compiler Classic.
+This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+
+
+About intel-cmplr-lic-rt
+------------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Intel End User License Agreement for Developer Tools
+
+Development: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+
+Intel End User License Agreement for Developer Tools.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
@@ -136,40 +200,6 @@ Intel End User License Agreement for Developer Tools.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
-About dpcpp-cpp-rt
-------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Runtime for Intel® oneAPI DPC++/C++ Compiler
-
-Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
-
-Runtime for Intel® oneAPI DPC++/C++ Compiler.
-This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
-
-
-About dpcpp_impl_linux-64
--------------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
-
-Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
-
-Implementation for Intel® oneAPI DPC++/C++ Compiler.
-This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
-
-
 About oneccl-devel
 ------------------
 
@@ -187,8 +217,46 @@ Intel® oneAPI Collective Communications Library*.
 This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
-About dpcpp_linux-64
---------------------
+About umf
+---------
+
+Home: https://github.com/oneapi-src/unified-memory-framework
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: A library for constructing allocators and memory pools
+
+Development: https://github.com/oneapi-src/unified-memory-framework
+
+Documentation: https://oneapi-src.github.io/unified-memory-framework/
+
+The Unified Memory Framework (UMF) is a library for constructing
+allocators and memory pools. It also contains broadly useful
+abstractions and utilities for memory management. UMF allows users to
+manage multiple memory pools characterized by different attributes,
+allowing certain allocation types to be isolated from others and
+allocated using different hardware resources as required.
+
+
+About dpcpp_impl_win-64
+-----------------------
+
+Home: https://software.intel.com/content/www/us/en/develop/tools.html
+
+Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
+
+Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
+
+Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
+
+Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
+
+Implementation for Intel® oneAPI DPC++/C++ Compiler.
+This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
+
+
+About dpcpp_win-64
+------------------
 
 Home: https://software.intel.com/content/www/us/en/develop/tools.html
 
@@ -221,23 +289,6 @@ Implementation for Intel® Fortran Compiler.
 This package is a repackaged set of binaries obtained directly from Intel channel.
 
 
-About dpcpp_impl_win-64
------------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
-
-Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
-
-Implementation for Intel® oneAPI DPC++/C++ Compiler.
-This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
-
-
 About ifx_win-64
 ----------------
 
@@ -253,23 +304,6 @@ Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi
 
 Activation for Intel® Fortran Compiler.
 This package is a repackaged set of binaries obtained directly from Intel channel.
-
-
-About dpcpp_win-64
-------------------
-
-Home: https://software.intel.com/content/www/us/en/develop/tools.html
-
-Package license: LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools
-
-Summary: Implementation for Intel® oneAPI DPC++/C++ Compiler
-
-Development: https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-
-Documentation: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
-
-Activation for Intel® oneAPI DPC++/C++ Compiler.
-This package is a repackaged set of binaries obtained directly from Intel's Anaconda.org channel.
 
 
 Current build status
@@ -359,12 +393,14 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp--cpp--rt-green.svg)](https://anaconda.org/conda-forge/dpcpp-cpp-rt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp-cpp-rt.svg)](https://anaconda.org/conda-forge/dpcpp-cpp-rt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp-cpp-rt.svg)](https://anaconda.org/conda-forge/dpcpp-cpp-rt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp-cpp-rt.svg)](https://anaconda.org/conda-forge/dpcpp-cpp-rt) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_impl_linux--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_impl_win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_linux--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp_win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_impl_win--64-green.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx_win--64-green.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp__impl__linux--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_impl_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_linux-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp__impl__win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_impl_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_impl_win-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp__linux--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_linux-64.svg)](https://anaconda.org/conda-forge/dpcpp_linux-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dpcpp__win--64-green.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dpcpp_win-64.svg)](https://anaconda.org/conda-forge/dpcpp_win-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx__impl__linux--64-green.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_impl_linux-64.svg)](https://anaconda.org/conda-forge/ifx_impl_linux-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx__impl__win--64-green.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_impl_win-64.svg)](https://anaconda.org/conda-forge/ifx_impl_win-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx__linux--64-green.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_linux-64.svg)](https://anaconda.org/conda-forge/ifx_linux-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ifx__win--64-green.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ifx_win-64.svg)](https://anaconda.org/conda-forge/ifx_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-intel--cmplr--lib--rt-green.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/intel-cmplr-lib-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-rt) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-intel--cmplr--lib--ur-green.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/intel-cmplr-lib-ur.svg)](https://anaconda.org/conda-forge/intel-cmplr-lib-ur) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-intel--cmplr--lic--rt-green.svg)](https://anaconda.org/conda-forge/intel-cmplr-lic-rt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/intel-cmplr-lic-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lic-rt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/intel-cmplr-lic-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lic-rt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/intel-cmplr-lic-rt.svg)](https://anaconda.org/conda-forge/intel-cmplr-lic-rt) |
@@ -384,16 +420,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `dpcpp-cpp-rt, dpcpp_impl_linux-64, dpcpp_impl_win-64, dpcpp_linux-64, dpcpp_win-64, ifx_impl_win-64, ifx_win-64, intel-cmplr-lib-rt, intel-cmplr-lib-ur, intel-cmplr-lic-rt, intel-fortran-rt, intel-opencl-rt, intel-sycl-rt, oneccl-devel, umf` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `dpcpp-cpp-rt, dpcpp_impl_linux-64, dpcpp_impl_win-64, dpcpp_linux-64, dpcpp_win-64, ifx_impl_linux-64, ifx_impl_win-64, ifx_linux-64, ifx_win-64, intel-cmplr-lib-rt, intel-cmplr-lib-ur, intel-cmplr-lic-rt, intel-fortran-rt, intel-opencl-rt, intel-sycl-rt, oneccl-devel, umf` can be installed with `conda`:
 
 ```
-conda install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_win-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
+conda install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_linux-64 ifx_impl_win-64 ifx_linux-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
 ```
 
 or with `mamba`:
 
 ```
-mamba install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_win-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
+mamba install dpcpp-cpp-rt dpcpp_impl_linux-64 dpcpp_impl_win-64 dpcpp_linux-64 dpcpp_win-64 ifx_impl_linux-64 ifx_impl_win-64 ifx_linux-64 ifx_win-64 intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-fortran-rt intel-opencl-rt intel-sycl-rt oneccl-devel umf
 ```
 
 It is possible to list all of the versions of `dpcpp-cpp-rt` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set version = "2025.1.0" %}
 # work-around for https://github.com/conda/conda-build/issues/5443
 {% set intel_build_number = "dummy" %}
-{% set intel_build_number = "974" %}   # [linux]
-{% set intel_build_number = "973" %}   # [win]
+{% set intel_build_number = "973" %}   # [linux]
+{% set intel_build_number = "972" %}   # [win]
 
 {% set oneccl_version = "2021.15.0" %}
 {% set oneccl_build_number = "397" %}
@@ -16,7 +16,7 @@
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '0' %}
+{% set dst_build_number = '1' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set version = "2025.1.0" %}
 # work-around for https://github.com/conda/conda-build/issues/5443
 {% set intel_build_number = "dummy" %}
-{% set intel_build_number = "973" %}   # [linux]
-{% set intel_build_number = "972" %}   # [win]
+{% set intel_build_number = "974" %}   # [linux]
+{% set intel_build_number = "973" %}   # [win]
 
 {% set oneccl_version = "2021.15.0" %}
 {% set oneccl_build_number = "397" %}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The intel-cmplr-lib-ur package previously depended on 2025.1.0 version of umf, when it should be 0.10.0. We fixed the version issue here: https://github.com/conda-forge/intel-compiler-repack-feedstock/pull/62. However, because intel-cmplr-lib-ur's version and build number stayed the same, there was no way for the package to have corrected metadata upstream (conda-forge would see the package already exists in the repo and isn't going to overwrite it). Incrementing the build number should fix this.