### PR TITLE
Bump dst_build_number so umf and oneccl-devel are actually published

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,17 @@
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '1' %}
+#
+# NOTE: `umf` and `oneccl-devel` keep their own upstream build numbers, because
+# they are versioned independently of the compiler and `intel_build_number`
+# restarts on every compiler release (947 -> 235 -> 325), which would make their
+# build number go backwards for an unchanged version. As a consequence their
+# build string does not change when only `version`/`intel_build_number` are
+# bumped, so a compiler release update must also bump `dst_build_number` --
+# otherwise those two outputs are silently dropped by the output validation and
+# keep exact-pinning `intel-cmplr-lic-rt`/`intel-sycl-rt` from the previous
+# release.
+{% set dst_build_number = '2' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:


### PR DESCRIPTION
## Problem

`intel-sycl-rt 2026.1.1` is not installable on `linux-64` or `win-64`:

```
intel-sycl-rt 2026.1.1 → intel-cmplr-lib-rt 2026.1.1 → intel-cmplr-lic-rt 2026.1.1  ─┐
intel-sycl-rt 2026.1.1 → intel-cmplr-lib-ur 2026.1.1 → umf 1.1.0 h7d1de2b_341        ├─ conflict
                                                     → intel-cmplr-lic-rt 2026.0.0  ─┘
```

`umf 1.1.0` here is still the 2026-05-13 build and exact-pins `intel-cmplr-lic-rt 2026.0.0`.
`oneccl-devel` has the same issue in a quieter form — it installs, but silently pulls in
compiler `2026.0.0`. `2026.1.0` is broken the same way.

## Cause

`umf` and `oneccl-devel` keep their own upstream build counters rather than the shared
`build_number`, which is correct (they version independently of the compiler, and
`intel_build_number` restarts every release, so a shared counter would go backwards).
The side effect is that their build string is invariant across compiler releases — and
`conda_forge_output_validation` silently rejects an artifact whose build string already
exists on the channel, while CI stays green. So #84 and #85 published new compiler
outputs but no new `umf` / `oneccl-devel`. Same failure class as #62 / #63.

## Fix

```diff
-{% set dst_build_number = '1' %}
+{% set dst_build_number = '2' %}
```

| output | linux-64 | win-64 |
|---|---|---|
| main outputs | 326 → **327** | 328 → **329** |
| `umf 1.1.0` | 341 → **342** | 339 → **340** |
| `oneccl-devel` | 49302 → **49303** | n/a |

All strictly above the published maximum, so nothing is dropped this time.

## Verification

Rendered for both platforms; the pins close the chain (`umf` → `lic-rt 2026.1.1`,
`lib-ur` → `umf _342`, `oneccl-devel` → `intel-sycl-rt 2026.1.1`). A channel built from
the render solves `intel-sycl-rt`, `dpcpp-cpp-rt`, `oneccl-devel` and `intel-opencl-rt`
(4/4); all four fail against the current channel.

## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (version unchanged)
- [x] Ensured the license file is being packaged
